### PR TITLE
fix: Boot-Crash der Release-.exe durch smtp.*-Placeholder ohne Default (Issue #68)

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
-# Graph Report - ERP-System-fuer-Handwerksbetriebe  (2026-07-03)
+# Graph Report - ERP-System-fuer-Handwerksbetriebe  (2026-07-06)
 
 ## Corpus Check
-- 1231 files · ~1,122,454 words
+- 1232 files · ~1,122,841 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 10969 nodes · 21293 edges · 815 communities (382 shown, 433 thin omitted)
-- Extraction: 73% EXTRACTED · 27% INFERRED · 0% AMBIGUOUS · INFERRED: 5649 edges (avg confidence: 0.8)
+- 10974 nodes · 21303 edges · 813 communities (384 shown, 429 thin omitted)
+- Extraction: 73% EXTRACTED · 27% INFERRED · 0% AMBIGUOUS · INFERRED: 5653 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `3055e48d`
+- Built from commit: `75a7904b`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -733,10 +733,7 @@
 - [[_COMMUNITY_Community 789|Community 789]]
 - [[_COMMUNITY_Community 790|Community 790]]
 - [[_COMMUNITY_Community 791|Community 791]]
-- [[_COMMUNITY_Community 792|Community 792]]
 - [[_COMMUNITY_Community 793|Community 793]]
-- [[_COMMUNITY_Community 794|Community 794]]
-- [[_COMMUNITY_Community 795|Community 795]]
 - [[_COMMUNITY_Community 796|Community 796]]
 - [[_COMMUNITY_Community 797|Community 797]]
 - [[_COMMUNITY_Community 798|Community 798]]
@@ -776,35 +773,31 @@
 - `MarkdownText()` --calls--> `fmt()`  [INFERRED]
   react-pc-frontend/src/components/KiHilfeChat.tsx → react-zeiterfassung/src/pages/BelegPositionenAuswahlPage.tsx
 
-## Communities (815 total, 433 thin omitted)
+## Communities (813 total, 429 thin omitted)
 
 ### Community 0 - "Community 0"
 Cohesion: 0.03
-Nodes (122): FONT_SIZES, FontSizeCommandChain, FontSizeEditorCommands, ResizableImage, TiptapEditor(), TiptapEditorProps, TiptapEditorRef, TiptapToolbar() (+114 more)
+Nodes (125): FONT_SIZES, FontSizeCommandChain, FontSizeEditorCommands, ResizableImage, TiptapEditor(), TiptapEditorProps, TiptapEditorRef, TiptapToolbar() (+117 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.05
-Nodes (46): DocumentCard(), DocumentCardProps, DocumentGroup(), DocumentGroupProps, DocumentManagerProps, DocumentPreviewModal(), DocumentPreviewModalProps, DropzoneEmpty() (+38 more)
+Cohesion: 0.06
+Nodes (34): AnfrageSearchModal(), AnfrageSearchModalProps, mockFetch, onClose, onSelect, search, user, filterBlocksBySelectedIds() (+26 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.03
-Nodes (26): LeistungMapperTest, ToEntity, UpdateEntity, KostenstelleMapping, MieteMapperTest, MietobjektMapping, MietparteiMapping, RaumMapping (+18 more)
+Cohesion: 0.05
+Nodes (13): LeistungMapperTest, ToEntity, UpdateEntity, KostenstelleMapping, RaumMapping, VerbrauchsgegenstandMapping, CopyVorjahr, KostenstellenCrud (+5 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.07
 Nodes (11): Abrechnungsverlauf, AusgangsGeschaeftsDokumentControllerTest, Buchen, Create, EmailVersendet, GetByAnfrage, GetByProjekt, GetPdf (+3 more)
 
 ### Community 5 - "Community 5"
-Cohesion: 0.02
-Nodes (96): CategoryMultiSelectModal(), CategoryMultiSelectModalProps, SelectedCategory, mockFetch, mockHauptkategorien, mockSearchResults, onClose, onConfirm (+88 more)
+Cohesion: 0.03
+Nodes (73): ArtikelImportModal(), ArtikelImportModalProps, autoMapHeaders(), createInitialMappings(), DEFAULT_HEADER_CANDIDATES, FIELD_DEFINITIONS, FieldDefinition, IMPORT_FEEDBACK_STEPS (+65 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.03
-Nodes (85): KategorieAnalyseModal(), KategorieAnalyseModalProps, analyseResponse, angezeigteFixzeit, Chart, kategorie, kleinsteAuftragsdauer, mockFetch (+77 more)
-
-### Community 7 - "Community 7"
-Cohesion: 0.05
-Nodes (11): KundeController, Projekt, EmailAddressChangedEvent, KundeCreateRequestDto, KundeUpdateRequestDto, AnfrageMapper, AnfrageMapperTest, KundeMapper (+3 more)
+Nodes (88): EmailHistoryProps, KategorieAnalyseModal(), KategorieAnalyseModalProps, analyseResponse, angezeigteFixzeit, Chart, kategorie, kleinsteAuftragsdauer (+80 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.03
@@ -812,23 +805,15 @@ Nodes (24): addOnPostRun(), addOnPreRun(), addRunDependency(), callRuntimeCallba
 
 ### Community 9 - "Community 9"
 Cohesion: 0.03
-Nodes (19): addOnPostRun(), addOnPreRun(), addRunDependency(), callRuntimeCallbacks(), createWasm(), doCallback(), done(), _emscripten_get_environ() (+11 more)
+Nodes (26): addOnPostRun(), addOnPreRun(), addRunDependency(), alignUp(), callRuntimeCallbacks(), createWasm(), doCallback(), done() (+18 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.11
-Nodes (5): VendorInvoiceController, VendorInvoiceIntegrationService, DoppelteRechnungen, FehlendeLieferantenZuordnung, VendorInvoiceIntegrationServiceTest
-
-### Community 11 - "Community 11"
-Cohesion: 0.10
-Nodes (5): ReanalyzeByLieferant, LieferantDokumentRepository, LieferantDokumentServiceTest, LieferantenDetailServiceTest, LoadDetails
+Cohesion: 0.06
+Nodes (7): LieferantenControllerTest, VendorInvoiceController, VendorInvoiceIntegrationService, DoppelteRechnungen, FehlendeLieferantenZuordnung, IntegrationStatus, VendorInvoiceIntegrationServiceTest
 
 ### Community 12 - "Community 12"
 Cohesion: 0.03
-Nodes (99): AnfrageSearchModal(), AnfrageSearchModalProps, mockFetch, onClose, onSelect, search, user, AnalyzeResponse (+91 more)
-
-### Community 13 - "Community 13"
-Cohesion: 0.13
-Nodes (5): AusgangsrechnungDto, EingangsrechnungDto, MergePdfRequest, RechnungsuebersichtController, LieferantDokument
+Nodes (54): OpenFileLauncherSetup(), Kategorie, ProjektKategorieTreeModal(), ProjektKategorieTreeModalProps, TreeNode(), TreeNodeProps, Projekt, ProjektSearchModal() (+46 more)
 
 ### Community 14 - "Community 14"
 Cohesion: 0.17
@@ -836,11 +821,15 @@ Nodes (4): GeminiDokumentAnalyseServiceTest, JsonTruncationHandling, Zahlungsart
 
 ### Community 15 - "Community 15"
 Cohesion: 0.18
-Nodes (3): AuditChainRepairAlgorithmTest, AuditChainRepairService, AuditChainVerifierTest
+Nodes (4): AuditChainRepairService, AuditChainVerifier, Bericht, AuditChainVerifierTest
 
 ### Community 17 - "Community 17"
-Cohesion: 0.05
-Nodes (40): DocumentPreviewModal(), isPdfUrl(), PreviewDoc, KundeSearchItem, KundeSearchModal(), KundeSearchModalProps, isPdfUrl(), AUSGANGS_TYP_BADGE (+32 more)
+Cohesion: 0.13
+Nodes (5): EmailTemplateController, EmailTemplateRequest, EmailTemplateResponse, EmailService, getDisplayName()
+
+### Community 18 - "Community 18"
+Cohesion: 0.15
+Nodes (3): QrCodeUndToken, MitarbeiterNotizRepository, MitarbeiterService
 
 ### Community 19 - "Community 19"
 Cohesion: 0.16
@@ -848,67 +837,75 @@ Nodes (5): PushSubscriptionController, GetVapidKey, PushSubscriptionControllerTe
 
 ### Community 20 - "Community 20"
 Cohesion: 0.05
-Nodes (7): ProjektMapperTest, AnfrageNotizRepository, ProjektDokumentRepositoryTest, AktualisiereStundensaetze, ProjektManagementService, ProjektManagementServiceTest, ProjektPersistenceService
+Nodes (6): ProjektMapperTest, AnfrageNotizRepository, AktualisiereStundensaetze, ProjektManagementService, ProjektManagementServiceTest, ProjektPersistenceService
 
 ### Community 21 - "Community 21"
 Cohesion: 0.08
-Nodes (12): AllCapsBetreff, DomainBlacklist, ErstkontaktHeuristik, GefaehrlicheDateitypen, ImageSpam, LieferantenWhitelist, LinkDichte, RechnungMitPdfKeinSpam (+4 more)
+Nodes (13): AllCapsBetreff, DomainBlacklist, ErstkontaktHeuristik, GefaehrlicheDateitypen, ImageSpam, IsSpamMethode, LieferantenWhitelist, LinkDichte (+5 more)
 
 ### Community 22 - "Community 22"
 Cohesion: 0.08
 Nodes (6): EmailKiClassificationController, EmailKiClassificationControllerTest, EmailKiClassificationService, isAssigned(), none(), EmailKiClassificationServiceTest
 
+### Community 23 - "Community 23"
+Cohesion: 0.10
+Nodes (5): BelegControllerTest, MobileBelegeListe, SteuerberaterExport, KasseShortcutController, ZahlungsartController
+
 ### Community 24 - "Community 24"
-Cohesion: 0.18
-Nodes (8): AtomaresDokumentErstellen, BackfillXmlAufPdf, BereitsVerarbeiteteAnhaenge, DateipfadAufloesung, DokumenttypErkennung, EmailAttachmentProcessingServiceTest, PdfAnhangVerarbeitung, PdfXmlPaarung
+Cohesion: 0.16
+Nodes (9): LieferantDokumentRepositoryTest, AtomaresDokumentErstellen, BackfillXmlAufPdf, BereitsVerarbeiteteAnhaenge, DateipfadAufloesung, DokumenttypErkennung, EmailAttachmentProcessingServiceTest, PdfAnhangVerarbeitung (+1 more)
+
+### Community 26 - "Community 26"
+Cohesion: 0.07
+Nodes (4): Zeitkonto, MonatsSaldoWarmupService, SummiereKorrekturen, ZeitkontoService
 
 ### Community 28 - "Community 28"
 Cohesion: 0.06
 Nodes (5): ArtikelKategorieController, ArtikelKategorieControllerTest, KategorieRepository, KategorieService, KategorieServiceTest
 
 ### Community 29 - "Community 29"
-Cohesion: 0.09
-Nodes (9): ArtikelControllerTest, Artikel, LieferantenArtikelPreise, ArtikelCascadeDeletionTest, ArtikelRepositoryTest, LieferantArtikelpreisMapper, LieferantArtikelpreisService, OfferPriceService (+1 more)
+Cohesion: 0.10
+Nodes (8): ArtikelControllerTest, Artikel, LieferantenArtikelPreise, ArtikelCascadeDeletionTest, ArtikelRepositoryTest, LieferantArtikelpreisMapper, OfferPriceService, OfferPriceServiceTest
 
 ### Community 30 - "Community 30"
-Cohesion: 0.05
-Nodes (36): Kunde, KundenPageProps, Lieferant, LieferantenPageProps, LieferantRaw, Arbeitsgang, Produktkategorie, Projekt (+28 more)
+Cohesion: 0.06
+Nodes (30): Arbeitsgang, Produktkategorie, Projekt, Step, ZeiterfassungPageProps, buildBookingRequestPayload(), CACHE_KEYS, createOperationId() (+22 more)
 
 ### Community 31 - "Community 31"
-Cohesion: 0.07
-Nodes (5): UrlaubsantragControllerTest, UrlaubsantragPage(), AbwesenheitRepository, UrlaubsantragRepository, UrlaubsantragService
+Cohesion: 0.06
+Nodes (9): UrlaubsantragControllerTest, Feiertag, STATUS_FILTER_OPTIONS, Urlaubsantrag, UrlaubsantragPage(), UrlaubsantragPageProps, AbwesenheitRepository, UrlaubsantragRepository (+1 more)
 
-### Community 33 - "Community 33"
-Cohesion: 0.07
-Nodes (4): LieferantenArtikelPreiseRepository, emptyToNull(), parse(), GeminiDokumentAnalyseService
-
-### Community 34 - "Community 34"
-Cohesion: 0.07
-Nodes (27): anredeEnumToText(), deriveOrderRecipientName(), EmailComposeForm(), EmailComposeFormProps, EmailTemplateResponse, formatFileSize(), FrontendUserSelection, SignatureResponse (+19 more)
+### Community 35 - "Community 35"
+Cohesion: 0.14
+Nodes (3): GaebImportController, EmailClassificationGeminiClient, GaebImportService
 
 ### Community 36 - "Community 36"
-Cohesion: 0.06
-Nodes (7): ArbeitsgangController, ZeitverwaltungController, Zeitbuchung, Zeitkonto, ArbeitsgangMapper, ArbeitsgangMapperTest, ArbeitsgangStundensatzRepository
+Cohesion: 0.26
+Nodes (3): ArbeitsgangMapper, ArbeitsgangMapperTest, ArbeitsgangStundensatzRepository
 
 ### Community 38 - "Community 38"
-Cohesion: 0.08
-Nodes (9): Delete, GetById, Abrechnungsverlauf, Aktualisieren, AusgangsGeschaeftsDokumentServiceTest, Buchen, EnsureAnfrageDokument, Loeschen (+1 more)
+Cohesion: 0.09
+Nodes (8): Delete, GetById, Abrechnungsverlauf, Aktualisieren, AusgangsGeschaeftsDokumentServiceTest, Buchen, Loeschen, Stornieren
 
 ### Community 40 - "Community 40"
-Cohesion: 0.11
-Nodes (17): Kategorie, ProjektKategorieTreeModal(), ProjektKategorieTreeModalProps, TreeNode(), TreeNodeProps, Projekt, ProjektSearchModal(), ProjektSearchModalProps (+9 more)
+Cohesion: 0.10
+Nodes (14): BILLING_UNITS, FolderDescriptionForm(), FolderDescriptionFormProps, FolderTreeNode(), FolderTreeNodeProps, FolderTreeProps, getFolderPath(), LeistungApiResponse (+6 more)
 
 ### Community 42 - "Community 42"
 Cohesion: 0.04
 Nodes (45): dependencies, html5-qrcode, idb, jscanify, jspdf, lucide-react, react, react-dom (+37 more)
 
 ### Community 43 - "Community 43"
-Cohesion: 0.08
-Nodes (5): LieferantBildDto, LieferantenController, LieferantCreateRequestDto, LieferantUpdateRequestDto, LieferantNotizRepository
+Cohesion: 0.06
+Nodes (6): LieferantBildDto, LieferantenController, LieferantDokument, LieferantCreateRequestDto, LieferantUpdateRequestDto, LieferantNotizRepository
+
+### Community 45 - "Community 45"
+Cohesion: 0.04
+Nodes (7): body, AnfrageFunnelController, LohnStammdatenController, ProjektController, ExternalSpamFilterChatBackendTest, OllamaServiceTest, method
 
 ### Community 46 - "Community 46"
-Cohesion: 0.05
-Nodes (44): AuthContext, AuthContextValue, AuthProvider(), AuthUser, LoginResult, RegisterResult, useAuth(), RequireAdmin() (+36 more)
+Cohesion: 0.04
+Nodes (47): AuthContext, AuthContextValue, AuthProvider(), AuthUser, LoginResult, RegisterResult, useAuth(), RequireAdmin() (+39 more)
 
 ### Community 47 - "Community 47"
 Cohesion: 0.09
@@ -919,20 +916,20 @@ Cohesion: 0.11
 Nodes (5): ArbeitsgangManagementService, ArbeitsgangManagementServiceTest, ErstelleArbeitsgang, FindeAlle, LoescheArbeitsgang
 
 ### Community 49 - "Community 49"
-Cohesion: 0.10
-Nodes (8): installSessionInterceptor(), isAuthEndpoint(), ExternalSpamFilterChatBackendTest, method, originalFetch, rootElement, STATE_CHANGING_METHODS, token
+Cohesion: 0.25
+Nodes (6): installSessionInterceptor(), isAuthEndpoint(), originalFetch, rootElement, STATE_CHANGING_METHODS, token
 
 ### Community 50 - "Community 50"
-Cohesion: 0.21
-Nodes (6): C, ce(), fe, le(), U, X()
+Cohesion: 0.16
+Nodes (9): request(), fetchAnfrageLastAccessed(), trackAnfrageAccess(), fetchProjektLastAccessed(), trackProjektAccess(), isServerReachable(), fe, le() (+1 more)
 
 ### Community 51 - "Community 51"
-Cohesion: 0.07
+Cohesion: 0.08
 Nodes (10): FontSize, Modus, isSectionHeader(), isSeparator(), isService(), isSubtotal(), isText(), RechnungPdfService (+2 more)
 
 ### Community 52 - "Community 52"
-Cohesion: 0.16
-Nodes (3): ProjektAuswertungPdfService, BuildComparatorTests, GroupByLabelTests
+Cohesion: 0.13
+Nodes (5): KundeCreateRequestDto, KundeUpdateRequestDto, AnfrageMapper, AnfrageMapperTest, KundeMapper
 
 ### Community 53 - "Community 53"
 Cohesion: 0.05
@@ -941,6 +938,10 @@ Nodes (37): 🤖 AI 生成全流程, code:block1 (assets/sfx/), code:bash (# 单
 ### Community 54 - "Community 54"
 Cohesion: 0.05
 Nodes (38): 1. 浏览器渲染检查（必做）, 2. 控制台错误检查, 3. 多视口检查, 4. 交互检查, 5. 幻灯片逐页检查, code:bash (open -a "Google Chrome" "/path/to/your/design.html"), code:python (page = browser.new_page(device_scale_factor=2)  # retina), code:python (page.wait_for_timeout(2000)  # 等2秒让动画settle) (+30 more)
+
+### Community 56 - "Community 56"
+Cohesion: 0.05
+Nodes (3): Inbox, EmailRepository, EmailCleanupService
 
 ### Community 57 - "Community 57"
 Cohesion: 0.10
@@ -955,32 +956,32 @@ Cohesion: 0.05
 Nodes (36): BGM 选择决策树, code:bash ([bgm_raw]lowpass=f=4000[bgm]      # BGM 限制在 <4kHz 的中低频), code:block2 (动画性格是什么？), code:block3 (时长：25 秒), code:block4 (时长：30-45 秒), code:block5 (时长：15-20 秒), code:block6 (时长：10-15 秒), code:bash (ffmpeg -y -i video.mp4 -itsoffset 2.5 -i sfx.mp3 \) (+28 more)
 
 ### Community 62 - "Community 62"
-Cohesion: 0.07
-Nodes (11): AnfrageDokument, AnfrageNotizBildDto, AnfrageNotizDto, EingangsrechnungDto, AnfrageGeschaeftsdokument, ProjektGeschaeftsdokument, ProjektDokument, CategoryAggregation (+3 more)
+Cohesion: 0.06
+Nodes (17): AnfrageDokument, AnfrageNotizBildDto, AnfrageNotizDto, EingangsrechnungDto, AnteilDto, DokumentKetteRefDto, EingangsrechnungDto, ProjektNotizBildDto (+9 more)
 
 ### Community 63 - "Community 63"
-Cohesion: 0.09
-Nodes (4): AusgangsGeschaeftsDokumentCounterRepository, AusgangsGeschaeftsDokumentRepository, Erstellen, RechnungsadresseVererbung
+Cohesion: 0.10
+Nodes (3): AusgangsGeschaeftsDokumentRepository, Erstellen, RechnungsadresseVererbung
 
 ### Community 64 - "Community 64"
 Cohesion: 0.05
-Nodes (7): AnfrageController, LieferantReklamationController, LieferscheinSearchDto, AnfrageDokument, Dokument, MitarbeiterDokument, ProjektDokument
+Nodes (4): AnfrageController, AnfrageControllerTest, AnfrageService, AnfrageServiceTest
 
 ### Community 65 - "Community 65"
 Cohesion: 0.09
-Nodes (26): ae, be, cacheWillUpdate(), de(), $e, Ee(), f, ge (+18 more)
+Nodes (27): ae, be, C, cacheWillUpdate(), ce(), $e, f, ge (+19 more)
 
 ### Community 66 - "Community 66"
 Cohesion: 0.06
 Nodes (35): 1. SVG noise texture, 1. 悬浮卡片（整个风格的基本单元）, 2. 3D倾斜作品墙, 2. 角落品牌标识, 3. 2×2 四角汇聚（选择场景）, 3. 品牌收束 wordmark, Apple Gallery Showcase · 画廊展示墙动画风格, code:css (:root {) (+27 more)
 
 ### Community 67 - "Community 67"
-Cohesion: 0.11
-Nodes (3): SteuerberaterKontaktRepository, SteuerberaterEmailProcessingServiceTest, SteuerberaterKontaktService
+Cohesion: 0.05
+Nodes (36): Kostenstelle, KostenstelleSelectModal(), KostenstelleSelectModalProps, ProjectSelectModal(), ProjectSelectModalProps, Projekt, formatDate(), formatEuro() (+28 more)
 
 ### Community 68 - "Community 68"
-Cohesion: 0.16
-Nodes (28): craftInvokerFunction(), createNamedFunction(), __embind_finalize_value_array(), __embind_finalize_value_object(), __embind_register_class(), __embind_register_class_class_function(), __embind_register_class_constructor(), __embind_register_class_function() (+20 more)
+Cohesion: 0.11
+Nodes (34): __embind_finalize_value_array(), __embind_finalize_value_object(), __embind_register_bool(), __embind_register_class_class_function(), __embind_register_class_constructor(), __embind_register_class_function(), __embind_register_constant(), __embind_register_emval() (+26 more)
 
 ### Community 69 - "Community 69"
 Cohesion: 0.12
@@ -995,39 +996,39 @@ Cohesion: 0.06
 Nodes (34): 10. 录屏开头几秒动画重复 —— Warmup 帧泄漏, 11. 画面内别画「伪 chrome」—— 装饰版 player UI 与真 chrome 撞车, 12. 录屏前置空白 + 录屏起点偏移 —— `__ready` × tick × lastTick 三联陷阱, 13. 录制时禁止 loop —— `window.__recording` 信号, 14. 60fps 视频默认用帧复制 —— minterpolate 兼容性差, 15. `file://` + 外部 `.jsx` 的 CORS 陷阱 —— 单文件交付必须内联引擎, 16. 跨 scene 反色上下文 —— 画面内元素不要硬编码颜色, 1. 叠层布局 —— `position: relative` 是默认义务 (+26 more)
 
 ### Community 72 - "Community 72"
-Cohesion: 0.09
+Cohesion: 0.11
 Nodes (4): KundeControllerTest, getScore(), KundeDuplikatService, KundeDuplikatServiceTest
 
+### Community 73 - "Community 73"
+Cohesion: 0.16
+Nodes (3): istAusgang(), istKassenBewegung(), BelegeKasseExportPdfService
+
 ### Community 74 - "Community 74"
-Cohesion: 0.13
-Nodes (4): istAusgang(), istKassenBewegung(), KasseSaldoService, KasseSaldoServiceTest
+Cohesion: 0.11
+Nodes (14): allButtons, anfrageResults, anfrageTab, deleteButtons, globeButton, headings, mockEmails, mockStats (+6 more)
 
 ### Community 76 - "Community 76"
 Cohesion: 0.06
 Nodes (33): 3 个候选尺寸对比, 4 条硬约束（违反会直接报错）, body 写法三选一（等价）, code:css (body { width: 960pt;  height: 540pt; }    /* 最清晰，推荐 */), code:block10 (原设计 → editable 版调整), code:js (const pptx = new pptxgen();), code:html (<!-- ❌ 错误：文字直接在 div 里 -->), code:css (/* ❌ 错误 */) (+25 more)
 
 ### Community 77 - "Community 77"
-Cohesion: 0.11
-Nodes (10): EmailAutoAssignmentServiceTest, FindPossibleAssignments, KeineZuordnung, KeywordMatching, KeywordMinimumlaenge, KundeEmailZuordnung, LieferantZuordnung, MultiStepFallback (+2 more)
+Cohesion: 0.08
+Nodes (13): EmailAutoAssignmentService, EntityOption, PossibleAssignments, EmailAutoAssignmentServiceTest, FindPossibleAssignments, KeineZuordnung, KeywordMatching, KeywordMinimumlaenge (+5 more)
 
 ### Community 78 - "Community 78"
-Cohesion: 0.07
-Nodes (6): SpamModelStatsRepository, SpamTokenCountRepository, SpamBayesService, Bootstrap, Tokenisierung, Training
+Cohesion: 0.14
+Nodes (3): SpamModelStatsRepository, SpamTokenCountRepository, Training
 
 ### Community 79 - "Community 79"
-Cohesion: 0.08
-Nodes (7): BestellungController, ArtikelInProjektRepository, BestellungPdfService, BestellungPdfServiceTest, BestellungServiceMappingTest, BestellungServiceTest, StuecklistePdfServiceTest
+Cohesion: 0.10
+Nodes (5): BestellungController, BestellungPdfService, BestellungPdfServiceTest, BestellungServiceMappingTest, BestellungServiceTest
 
 ### Community 80 - "Community 80"
-Cohesion: 0.11
-Nodes (3): MonatsSaldoRepository, MonatsSaldoService, Invalidierung
-
-### Community 81 - "Community 81"
-Cohesion: 0.08
-Nodes (3): FormularTemplateController, FormularTemplateTextbausteinDefaultRepository, FormularTextbausteinDefaultService
+Cohesion: 0.13
+Nodes (14): ABWESENHEIT_FARBEN, EventModal(), EventModalProps, FARB_OPTIONEN, Feiertag, getCurrentUserMitarbeiterId(), KalenderEintrag, KalenderTag (+6 more)
 
 ### Community 82 - "Community 82"
-Cohesion: 0.08
+Cohesion: 0.07
 Nodes (9): BackfillXmlToPdf, BlockSender, Delete, KundeLookup, MarkNotSpam, MarkRead, MarkSpam, Search (+1 more)
 
 ### Community 83 - "Community 83"
@@ -1035,16 +1036,12 @@ Cohesion: 0.06
 Nodes (31): 5 维度专家评审, code:block1 (npx skills add alchaincyf/huashu-design), code:bash (npx skills add alchaincyf/huashu-design), code:block3 (「做一份 AI 心理学的演讲 PPT，推荐 3 个风格方向让我选」), code:block4 (huashu-design/), Connect · 花生（花叔）, Demo 画廊, HTML Slides → 可编辑 PPTX (+23 more)
 
 ### Community 84 - "Community 84"
-Cohesion: 0.13
-Nodes (4): ModellStatus, Prediction, SpamBayesServiceTest, StatusGetter
+Cohesion: 0.09
+Nodes (6): SpamBayesService, Bootstrap, ModellStatus, Prediction, SpamBayesServiceTest, StatusGetter
 
 ### Community 85 - "Community 85"
 Cohesion: 0.10
 Nodes (3): FeiertagRepository, FeiertagService, FeiertagServiceTest
-
-### Community 87 - "Community 87"
-Cohesion: 0.07
-Nodes (8): ZeitkontoKorrektur, ZeitkontoKorrekturAudit, MitarbeiterNotizRepository, ZeitkontoKorrekturAuditRepository, ZeitbuchungAutoStopService, ZeitkontoKorrekturService, GetKorrekturen, SummiereKorrekturen
 
 ### Community 88 - "Community 88"
 Cohesion: 0.06
@@ -1067,19 +1064,23 @@ Cohesion: 0.21
 Nodes (3): KundeMapperTest, ToListItem, ToResponseDto
 
 ### Community 93 - "Community 93"
-Cohesion: 0.15
-Nodes (5): BekannteKundenEmails, EnsembleIntegration, IsSpamMethode, NewsletterErkennung, ZugeordneteEmails
+Cohesion: 0.10
+Nodes (6): ScanResult, SpamFilterService, BekannteKundenEmails, EnsembleIntegration, NewsletterErkennung, ZugeordneteEmails
+
+### Community 94 - "Community 94"
+Cohesion: 0.07
+Nodes (7): ZeitkontoKorrektur, ZeitkontoKorrekturAudit, ZeitkontoKorrekturAuditRepository, MonatsSaldoService, Invalidierung, ZeitkontoKorrekturService, GetKorrekturen
 
 ### Community 95 - "Community 95"
-Cohesion: 0.13
-Nodes (5): EmailTemplateController, EmailTemplateRequest, EmailTemplateResponse, EmailService, getDisplayName()
+Cohesion: 0.15
+Nodes (5): AbwesenheitController, emptyToNull(), parse(), failure(), success()
 
 ### Community 96 - "Community 96"
-Cohesion: 0.17
+Cohesion: 0.16
 Nodes (8): AbschlagsrechnungMitClosure, ContentBlockTests, EndToEndTests, FormBlockTypedTests, PlaceholderResolutionTests, RealTemplateTests, RechnungPdfServiceTest, WatermarkTests
 
 ### Community 97 - "Community 97"
-Cohesion: 0.04
+Cohesion: 0.05
 Nodes (15): GeschaeftsdatenRequest, LieferantDokumentController, UpdateDokumentRequest, Download, Duplicates, GetDokument, LieferantDokumentControllerTest, LoescheDokument (+7 more)
 
 ### Community 98 - "Community 98"
@@ -1095,12 +1096,12 @@ Cohesion: 0.06
 Nodes (7): EntityLastAccessed, EntityLastAccessedId, LieferantenArtikelPreiseId, Serializable, CodebaseIndexService, KiHilfeService, LocalRagService
 
 ### Community 102 - "Community 102"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (3): fromLabel(), DokumentnummerCounterRepository, FormularTemplateService
 
 ### Community 103 - "Community 103"
-Cohesion: 0.06
-Nodes (29): refreshNotifications(), AssignModal(), AssignModalProps, DraggableEmailWrapper(), DraggableEmailWrapperProps, DroppableFolderButton(), DroppableFolderButtonProps, EmailAttachment (+21 more)
+Cohesion: 0.03
+Nodes (70): AttachmentProps, EmailAttachmentCard(), EmailAttachmentCardProps, getAttachmentIcon(), isImageAttachment(), anredeEnumToText(), deriveOrderRecipientName(), EmailComposeForm() (+62 more)
 
 ### Community 104 - "Community 104"
 Cohesion: 0.07
@@ -1111,20 +1112,20 @@ Cohesion: 0.22
 Nodes (4): AnfrageFunnelSpamFilterService, ok(), spam(), AnfrageFunnelSpamFilterServiceTest
 
 ### Community 106 - "Community 106"
-Cohesion: 0.13
-Nodes (4): CopyVorjahr, KostenpositionenCrud, KostenVerteilungControllerTest, KostenpositionTests
+Cohesion: 0.06
+Nodes (6): KostenVerteilungController, KostenpositionenCrud, KostenVerteilungService, CopyKostenpositionenVonVorjahr, KostenpositionTests, MieteKostenstelleRepository
 
 ### Community 107 - "Community 107"
-Cohesion: 0.10
-Nodes (19): CHART_COLORS, ConversionRateDto, ErfolgsanalyseEditor(), formatCurrency(), formatPercent(), KategorieUmsatzVergleich, KostenstelleVergleich, KundenSortField (+11 more)
+Cohesion: 0.03
+Nodes (93): DetailLayout(), DetailLayoutProps, EmailSettings(), EmailSignature, fetchUserDefaultSignatureHtml(), FrontendUserSelection, getCurrentFrontendUser(), OutOfOfficeBackend (+85 more)
 
 ### Community 108 - "Community 108"
-Cohesion: 0.16
-Nodes (4): Bezahlt, Genehmigen, OffeneEingangsrechnungen, OffenePostenControllerTest
+Cohesion: 0.13
+Nodes (5): AlleEingangsrechnungen, Bezahlt, Genehmigen, OffeneEingangsrechnungen, OffenePostenControllerTest
 
 ### Community 109 - "Community 109"
-Cohesion: 0.07
-Nodes (18): { container }, images, img, Notiz, NotizBild, PendingPhoto, Anfrage, AnfragesPageProps (+10 more)
+Cohesion: 0.09
+Nodes (14): { container }, images, img, Notiz, NotizBild, PendingPhoto, Anfrage, AnfragesPageProps (+6 more)
 
 ### Community 111 - "Community 111"
 Cohesion: 0.07
@@ -1132,7 +1133,7 @@ Nodes (27): 1a. Secrets-Scan (KRITISCH – bei Fund sofort abbrechen), 1b. Backe
 
 ### Community 112 - "Community 112"
 Cohesion: 0.08
-Nodes (17): AufteilungsModus, Auswertung, AuswertungZeile, Beleg, BelegPosition, BelegStatus, KassenBewegung, Kassenbuch (+9 more)
+Nodes (20): LieferantSearchModal(), LieferantSearchModalProps, LieferantSuchErgebnis, AufteilungsModus, Auswertung, AuswertungZeile, Beleg, BelegPosition (+12 more)
 
 ### Community 113 - "Community 113"
 Cohesion: 0.11
@@ -1143,8 +1144,8 @@ Cohesion: 0.07
 Nodes (27): code:html (<script src="https://unpkg.com/react@18.3.1/umd/react.develo), code:html (<input id="api-key" placeholder="粘贴你的Anthropic API key" />), code:html (<!DOCTYPE html>), code:block12 (项目/), code:html (<script type="text/babel" src="src/primitives.jsx"></script>), code:block2 (项目名/), code:html (<!-- 先React+Babel -->), code:jsx (// components.jsx) (+19 more)
 
 ### Community 115 - "Community 115"
-Cohesion: 0.07
-Nodes (9): Artikel, ArtikelHilfsstoffe, ArtikelWerkstoffe, ArtikelRepository, WerkstoffRepositoryTest, ArtikelImportService, ArtikelImportServiceTest, ArtikelService (+1 more)
+Cohesion: 0.06
+Nodes (10): Artikel, SchnittbilderController, ArtikelHilfsstoffe, ArtikelWerkstoffe, ArtikelRepository, SchnittbilderRepository, WerkstoffRepositoryTest, ArtikelService (+2 more)
 
 ### Community 117 - "Community 117"
 Cohesion: 0.17
@@ -1162,13 +1163,13 @@ Nodes (26): 1. **expoOut 作为主 easing，不是 cubicOut**, 2. **纸感底色
 Cohesion: 0.07
 Nodes (26): 1. 有意义的选项，不是折腾人的, 2. 少即是多, 3. 默认值是完成设计, 4. 合理分组, code:jsx (const TWEAK_DEFAULTS = {), code:jsx (function TweaksPanel() {), code:jsx (function App() {), code:css (button.cta {) (+18 more)
 
-### Community 122 - "Community 122"
-Cohesion: 0.11
-Nodes (4): BelegKostenstellenAnteilRepositoryTest, SvSatzRepository, SvKontext, VerrechnungslohnService
+### Community 121 - "Community 121"
+Cohesion: 0.15
+Nodes (3): FooterPageEvent, MietabrechnungPdfService, PdfPageEventHelper
 
 ### Community 123 - "Community 123"
-Cohesion: 0.16
-Nodes (5): AutoStoppeWennNoetig, MonatsSaldoInvalidierung, PruefUndStoppeOffeneBuchungen, ZeitbuchungAutoStopServiceTest, ZeiterfassungApiServiceConcurrencyTest
+Cohesion: 0.12
+Nodes (3): MitarbeiterRepository, ZeitbuchungRepository, ZeiterfassungApiServiceConcurrencyTest
 
 ### Community 125 - "Community 125"
 Cohesion: 0.07
@@ -1178,33 +1179,29 @@ Nodes (22): formatLocalDate(), MobileDatePickerProps, MONTHS, buttons, { contain
 Cohesion: 0.09
 Nodes (27): abort(), addFunctionWasm(), allocate(), assert(), _clock_gettime(), convertJsFunctionToWasm(), _emscripten_get_now(), _emscripten_get_now_is_monotonic() (+19 more)
 
-### Community 128 - "Community 128"
-Cohesion: 0.12
-Nodes (3): EmailAttachment, ScanResult, SpamFilterService
-
 ### Community 129 - "Community 129"
 Cohesion: 0.10
-Nodes (22): buildExclusiveItemTypesByCat(), buildItemKey(), CategoryDto, dismissCategory(), dismissItem(), filterDismissed(), gcOrphanedDismissals(), ITEM_TO_CAT_TYPES (+14 more)
+Nodes (23): buildExclusiveItemTypesByCat(), buildItemKey(), CategoryDto, dismissCategory(), dismissItem(), filterDismissed(), gcOrphanedDismissals(), ITEM_TO_CAT_TYPES (+15 more)
 
 ### Community 130 - "Community 130"
-Cohesion: 0.09
-Nodes (5): OutOfOfficeController, SaveOooRequest, OooReplyLogRepository, OutOfOfficeScheduleRepository, OutOfOfficeResponderTest
+Cohesion: 0.19
+Nodes (3): OooReplyLogRepository, OutOfOfficeScheduleRepository, OutOfOfficeResponderTest
 
 ### Community 131 - "Community 131"
-Cohesion: 0.10
-Nodes (4): ZeitbuchungAudit, AenderungsgrundKatalogRepository, ZeitbuchungAuditRepository, ZeitbuchungAuditService
+Cohesion: 0.07
+Nodes (7): ZeitverwaltungController, Zeitbuchung, ZeitbuchungAudit, AenderungsgrundKatalogRepository, ZeitbuchungAuditRepository, ZeitbuchungAuditService, ZeitbuchungAutoStopService
 
 ### Community 133 - "Community 133"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (3): BelegPositionRepository, BelegSplitService, BelegSplitServiceTest
-
-### Community 134 - "Community 134"
-Cohesion: 0.13
-Nodes (3): AbwesenheitController, AbwesenheitService, AbwesenheitServiceTest
 
 ### Community 136 - "Community 136"
 Cohesion: 0.12
 Nodes (4): after, EmailHtmlBackfillRunner, EmailHtmlSanitizer, EmailHtmlSanitizerTest
+
+### Community 137 - "Community 137"
+Cohesion: 0.11
+Nodes (6): PdfPCellEvent, ArtikelInProjektRepository, CheckboxCellEvent, LeftCheckboxCellEvent, StuecklistePdfService, StuecklistePdfServiceTest
 
 ### Community 138 - "Community 138"
 Cohesion: 0.19
@@ -1219,8 +1216,12 @@ Cohesion: 0.08
 Nodes (23): 1. Design Context（最重要）, 2. Variations维度, 3. Fidelity和Scope, 4. Tweaks, 5. 问题专属（至少4个）, code:markdown (开始前想跟你对齐几个问题，一次列齐你批量回答就行：), code:html (<!--), code:markdown (✅ 幻灯片已完成（10张），带Tweaks可切换"夜/日模式"。) (+15 more)
 
 ### Community 141 - "Community 141"
-Cohesion: 0.17
-Nodes (4): Dokumenttyp(), BelegKiAnalyseService, BelegKiAnalyseServiceTest, IntegrationStatus
+Cohesion: 0.20
+Nodes (3): Dokumenttyp(), BelegKiAnalyseService, BelegKiAnalyseServiceTest
+
+### Community 142 - "Community 142"
+Cohesion: 0.15
+Nodes (3): TextSplitter, BelegServiceKasseValidationTest, KasseSaldoService
 
 ### Community 143 - "Community 143"
 Cohesion: 0.08
@@ -1234,13 +1235,9 @@ Nodes (23): compilerOptions, allowImportingTsExtensions, erasableSyntaxOnly, for
 Cohesion: 0.08
 Nodes (23): 0 · 这份文档解决什么问题, 1 · 五个核心 pattern, 2 · 静态 Dashboard 设计要点, 3 · 调试与开发工具, 4 · iframe 嵌入坑（如果 cinematic 嵌在 deck 里）, 5 · 反 pattern 速查表, 6 · 时间预算, Cinematic Patterns · Workflow Demo 的 Best Practice (+15 more)
 
-### Community 147 - "Community 147"
-Cohesion: 0.29
-Nodes (3): ApplicationRunner, AuditChainRebuildRunner, FrontendUserBootstrapInitializer
-
 ### Community 148 - "Community 148"
-Cohesion: 0.08
-Nodes (17): LieferantReklamationDetailPage(), Reklamation, LieferantReklamationenPage(), Reklamation, Ergebnis, EUR, SetupPageProps, Feiertag (+9 more)
+Cohesion: 0.07
+Nodes (21): Kunde, KundenPageProps, Lieferant, LieferantenPageProps, LieferantRaw, LieferantReklamationDetailPage(), Reklamation, LieferantReklamationenPage() (+13 more)
 
 ### Community 151 - "Community 151"
 Cohesion: 0.09
@@ -1251,12 +1248,12 @@ Cohesion: 0.09
 Nodes (22): 1. `render-video.js` — HTML → MP4, 2. `add-music.sh` — MP4 + BGM → MP4, 3. `convert-formats.sh` — MP4 → 60fps MP4 + GIF, code:bash (NODE_PATH=$(npm root -g) node /path/to/claude-design/scripts), code:bash (bash add-music.sh <input.mp4> [--mood=<name>] [--music=<path), code:bash (node render-video.js animation.html                        #), code:bash (bash /path/to/claude-design/scripts/convert-formats.sh <inpu), code:bash (cd <项目目录>) (+14 more)
 
 ### Community 154 - "Community 154"
-Cohesion: 0.11
+Cohesion: 0.12
 Nodes (3): EmailAbsenderRepository, EmailAbsenderService, EmailAbsenderServiceTest
 
 ### Community 155 - "Community 155"
-Cohesion: 0.12
-Nodes (4): AendereKorrektur, ErstelleKorrektur, StorniereKorrektur, ZeitkontoKorrekturServiceTest
+Cohesion: 0.09
+Nodes (8): AutoStoppeWennNoetig, MonatsSaldoInvalidierung, PruefUndStoppeOffeneBuchungen, ZeitbuchungAutoStopServiceTest, AendereKorrektur, ErstelleKorrektur, StorniereKorrektur, ZeitkontoKorrekturServiceTest
 
 ### Community 156 - "Community 156"
 Cohesion: 0.26
@@ -1278,12 +1275,16 @@ Nodes (22): dependencies, chart.js, clsx, @dnd-kit/core, @dnd-kit/sortable, @dnd
 Cohesion: 0.09
 Nodes (22): devDependencies, autoprefixer, eslint, @eslint/js, eslint-plugin-react-hooks, eslint-plugin-react-refresh, globals, jsdom (+14 more)
 
+### Community 162 - "Community 162"
+Cohesion: 0.09
+Nodes (4): FirmaControllerLogoTest, FirmeninformationRepository, FirmeninformationService, FirmeninformationServiceTest
+
 ### Community 164 - "Community 164"
 Cohesion: 0.08
 Nodes (24): BASENAME, { chromium }, DIR, DURATION, ffmpeg, FONT_WAIT, fs, HEIGHT (+16 more)
 
 ### Community 165 - "Community 165"
-Cohesion: 0.07
+Cohesion: 0.06
 Nodes (4): FreigabeInternalController, DokumentFreigabe, DokumentFreigabeRepository, DokumentFreigabeService
 
 ### Community 166 - "Community 166"
@@ -1298,6 +1299,10 @@ Nodes (12): Lieferant, LieferantApiItem, SupplierSelectionModal(), SupplierSelec
 Cohesion: 0.07
 Nodes (27): ScannerModalProps, Corners, detectDocumentCorners(), detectDocumentCornersOnCanvasSync(), ensureLoaded(), JscanifyCtor, JscanifyInstance, OpenCV (+19 more)
 
+### Community 169 - "Community 169"
+Cohesion: 0.10
+Nodes (19): CHART_COLORS, ConversionRateDto, ErfolgsanalyseEditor(), formatCurrency(), formatPercent(), KategorieUmsatzVergleich, KostenstelleVergleich, KundenSortField (+11 more)
+
 ### Community 170 - "Community 170"
 Cohesion: 0.10
 Nodes (20): 📝 Anpassungen, Backups, code:powershell (.\update-production.ps1), code:powershell (# Build überspringen (nur wenn bereits gebaut)), code:block3 (C:\Kalkulationsprogramm\backups\), code:powershell (# Finde das gewünschte Backup), code:powershell (cd C:\Users\bausc\OneDrive\Dokumente\GitHub\Handwerkerprogra), code:powershell ($serviceName = "HandwerkerProgramm"  # Hier deinen Service-N) (+12 more)
@@ -1309,10 +1314,6 @@ Nodes (4): ConstraintMessageResolver, ConstraintMetadataBuilder, DatabaseConstra
 ### Community 172 - "Community 172"
 Cohesion: 0.18
 Nodes (3): ZugferdExtractorService, FallbackBeiUngueltigemPdf, GeschaeftsdokumentartErkennung
-
-### Community 173 - "Community 173"
-Cohesion: 0.11
-Nodes (6): Beautify, EmailControllerTest, Preview, PreviewAnfrage, Send, SendAnfrage
 
 ### Community 175 - "Community 175"
 Cohesion: 0.09
@@ -1332,11 +1333,11 @@ Nodes (3): DokumentLockRepository, DokumentLockService, DokumentLockServiceTest
 
 ### Community 179 - "Community 179"
 Cohesion: 0.07
-Nodes (30): EmailContentFrame(), EmailContentFrameProps, escapeHtml(), isLikelyPlainText(), tonlineMail, BubbleProps, decodeMimeWord(), DraftBubbleProps (+22 more)
+Nodes (29): EmailContentFrame(), EmailContentFrameProps, escapeHtml(), isLikelyPlainText(), tonlineMail, BubbleProps, decodeMimeWord(), DraftBubbleProps (+21 more)
 
 ### Community 180 - "Community 180"
-Cohesion: 0.10
-Nodes (4): MonatsSaldo, KostenpositionRepository, MietabrechnungServiceTest, VerbrauchsgegenstandRepository
+Cohesion: 0.17
+Nodes (3): KostenpositionRepository, MietabrechnungServiceTest, VerbrauchsgegenstandRepository
 
 ### Community 182 - "Community 182"
 Cohesion: 0.10
@@ -1346,21 +1347,29 @@ Nodes (19): compilerOptions, allowImportingTsExtensions, erasableSyntaxOnly, lib
 Cohesion: 0.10
 Nodes (19): compilerOptions, allowImportingTsExtensions, erasableSyntaxOnly, lib, module, moduleDetection, moduleResolution, noEmit (+11 more)
 
+### Community 187 - "Community 187"
+Cohesion: 0.10
+Nodes (5): KasseShortcutControllerTest, KasseEinstellungRepository, SachkontoRepository, EhegattengehaltSchedulerService, EhegattengehaltSchedulerServiceTest
+
 ### Community 188 - "Community 188"
-Cohesion: 0.07
-Nodes (4): LohnabrechnungController, LohnabrechnungRepository, LohnabrechnungService, LohnabrechnungServiceTest
+Cohesion: 0.09
+Nodes (3): LohnabrechnungController, LohnabrechnungRepository, LohnabrechnungService
 
 ### Community 190 - "Community 190"
 Cohesion: 0.15
 Nodes (4): EntityLastAccessedController, EntityLastAccessedRepository, EntityLastAccessedService, EntityLastAccessedServiceTest
 
+### Community 191 - "Community 191"
+Cohesion: 0.09
+Nodes (9): BelegZuordnungDto, BelegZuordnungRequest, BestellungsUebersichtController, DokumentRef, GeschaeftsdatenDto, ProjektAnteil, ZuordnungDto, ZuordnungRequest (+1 more)
+
 ### Community 192 - "Community 192"
-Cohesion: 0.11
-Nodes (3): EmailBlacklistRepository, BlacklistSkip, FallbackMessageId
+Cohesion: 0.08
+Nodes (5): EmailBlacklistRepository, EmailImportService, BlacklistSkip, FallbackMessageId, ParentEmailVerknuepfung
 
 ### Community 193 - "Community 193"
-Cohesion: 0.14
-Nodes (10): KiHilfeChat(), lsKey(), MarkdownText(), SourceLink, VALID_ROUTES, BelegPositionenAuswahlPage(), BelegResponse, EUR (+2 more)
+Cohesion: 0.29
+Nodes (6): MarkdownText(), BelegPositionenAuswahlPage(), BelegResponse, EUR, fmt(), Position
 
 ### Community 194 - "Community 194"
 Cohesion: 0.11
@@ -1379,24 +1388,24 @@ Cohesion: 0.14
 Nodes (18): __addDays(), __arraySum(), ccall(), demangle(), demangleAll(), getCFunc(), intArrayFromString(), __isLeapYear() (+10 more)
 
 ### Community 198 - "Community 198"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (17): Appointment, checkAndNotify(), CheckNotificationsMessage, cleanupOldSentEntries(), data, fetchAndCheckAppointments(), formatDate(), hasBeenSent() (+9 more)
+
+### Community 199 - "Community 199"
+Cohesion: 0.12
+Nodes (3): DokumentGeneratorController, SystemUtilityController, EmailSignatureImage
 
 ### Community 201 - "Community 201"
 Cohesion: 0.12
 Nodes (14): Apache License 2.0, BSD 3-Clause License, Drittanbieter-Lizenzen / Third-Party Licenses, EPL 2.0 / GPL 2.0 mit Classpath Exception, GPL 2.0 mit FOSS Exception, Hinweis, ISC License, Java Backend (+6 more)
 
 ### Community 202 - "Community 202"
-Cohesion: 0.12
-Nodes (4): BelegControllerTest, MobileBelegeListe, SteuerberaterExport, ZahlungsartController
+Cohesion: 0.16
+Nodes (6): FindAll, GetById, GetParteien, MietobjektServiceTest, Save, SavePartei
 
 ### Community 203 - "Community 203"
 Cohesion: 0.14
-Nodes (19): __addDays(), __arraySum(), ccall(), demangle(), demangleAll(), __embind_register_std_string(), getCFunc(), intArrayFromString() (+11 more)
-
-### Community 206 - "Community 206"
-Cohesion: 0.14
-Nodes (3): RestExceptionHandler, Message, MietabrechnungValidationException
+Nodes (18): __addDays(), __arraySum(), ccall(), demangle(), demangleAll(), getCFunc(), intArrayFromString(), __isLeapYear() (+10 more)
 
 ### Community 209 - "Community 209"
 Cohesion: 0.12
@@ -1407,8 +1416,8 @@ Cohesion: 0.10
 Nodes (4): AusgangsGeschaeftsDokument, MwstErgebnis, MwstRechnerService, MwstRechnerServiceTest
 
 ### Community 214 - "Community 214"
-Cohesion: 0.13
-Nodes (22): attachFinalizer(), ClassHandle_clone(), ClassHandle_delete(), ClassHandle_deleteLater(), constNoSmartPtrRawPointerToWireType(), detachFinalizer(), downcastPointer(), _embind_repr() (+14 more)
+Cohesion: 0.19
+Nodes (17): attachFinalizer(), ClassHandle_clone(), ClassHandle_delete(), ClassHandle_deleteLater(), constNoSmartPtrRawPointerToWireType(), detachFinalizer(), __embind_register_class_property(), _embind_repr() (+9 more)
 
 ### Community 216 - "Community 216"
 Cohesion: 0.12
@@ -1420,51 +1429,59 @@ Nodes (5): I(), k(), me, R, we()
 
 ### Community 218 - "Community 218"
 Cohesion: 0.03
-Nodes (56): AddressAutocomplete(), AddressAutocompleteProps, AddressValue, DEFAULT_COUNTRIES, NominatimItem, PhotonFeature, PhotonProperties, queryCache (+48 more)
+Nodes (67): AddressAutocomplete(), AddressAutocompleteProps, DEFAULT_COUNTRIES, NominatimItem, PhotonFeature, PhotonProperties, queryCache, searchNominatim() (+59 more)
+
+### Community 219 - "Community 219"
+Cohesion: 0.13
+Nodes (3): LieferantDokumentProjektAnteilRepository, LieferantStandardKostenstelleAutoAssigner, LieferantStandardKostenstelleAutoAssignerTest
 
 ### Community 220 - "Community 220"
 Cohesion: 0.16
 Nodes (8): AnalyzeResponse, Lieferant, Lieferschein, MultiInvoiceResponse, LieferantDokumentApi, LieferscheinResult, NotificationService, mockFetch
 
 ### Community 222 - "Community 222"
-Cohesion: 0.24
+Cohesion: 0.20
 Nodes (3): InquiryDetectionService, ScanResult, InquiryDetectionServiceTest
 
 ### Community 223 - "Community 223"
 Cohesion: 0.17
-Nodes (3): KostenVerteilungService, CopyKostenpositionenVonVorjahr, MieteKostenstelleRepository
+Nodes (3): KostenstelleTests, KostenVerteilungServiceTest, VerteilungsschluesselTests
 
 ### Community 224 - "Community 224"
 Cohesion: 0.13
 Nodes (13): BelegDto, KassenBewegung, KassenbuchResponse, KostenstellenSplitDto, MwstRechnerRequest, MwstRechnerResponse, PermissionResponse, PositionAuswahlRequest (+5 more)
 
 ### Community 225 - "Community 225"
-Cohesion: 0.07
-Nodes (3): ProduktkategorieController, ProduktkategorieRepository, ProduktkategorieService
+Cohesion: 0.04
+Nodes (8): ProduktkategorieController, LeistungMapper, ToDto, ProduktkategorieMapper, ProduktkategorieMapperTest, ProduktkategorieRepository, ProduktkategorieService, ProduktkategorieServiceSucheTest
 
 ### Community 226 - "Community 226"
-Cohesion: 0.14
+Cohesion: 0.18
 Nodes (4): LieferantMapper, LieferantMapperTest, ToDetailItem, ToListItem
 
 ### Community 227 - "Community 227"
-Cohesion: 0.17
-Nodes (3): ne(), pe, v()
+Cohesion: 0.13
+Nodes (7): de(), Ee(), h, ne(), pe, re(), v()
 
 ### Community 228 - "Community 228"
 Cohesion: 0.20
 Nodes (13): __dirname, main(), parseArgs(), addBackground(), addElements(), { chromium }, extractSlideData(), getBodyDimensions() (+5 more)
 
 ### Community 229 - "Community 229"
-Cohesion: 0.02
-Nodes (143): ArtikelImportModal(), ArtikelImportModalProps, autoMapHeaders(), createInitialMappings(), DEFAULT_HEADER_CANDIDATES, FIELD_DEFINITIONS, FieldDefinition, IMPORT_FEEDBACK_STEPS (+135 more)
+Cohesion: 0.03
+Nodes (112): AnalyzeResponse, AusgangsrechnungUploadModal(), AusgangsrechnungUploadModalProps, GESCHAEFTSDOKUMENTART_OPTIONS, Projekt, Step, CreateReklamationModal(), CreateReklamationModalProps (+104 more)
+
+### Community 232 - "Community 232"
+Cohesion: 0.07
+Nodes (6): LieferantReklamationController, LieferscheinSearchDto, AnfrageDokument, Dokument, MitarbeiterDokument, ProjektDokument
 
 ### Community 235 - "Community 235"
 Cohesion: 0.19
 Nodes (3): getAnzeigename(), EmailAbsenderDto, ProduktkategorieServiceAnalyseTest
 
 ### Community 237 - "Community 237"
-Cohesion: 0.12
-Nodes (5): KostenstelleTests, KostenVerteilungServiceTest, VerteilungsschluesselTests, empty(), PdfAiExtractorService
+Cohesion: 0.10
+Nodes (9): EmailControllerTest, Preview, PreviewAnfrage, Send, SendAnfrage, Delete, DeletePartei, empty() (+1 more)
 
 ### Community 239 - "Community 239"
 Cohesion: 0.14
@@ -1479,24 +1496,20 @@ Cohesion: 0.17
 Nodes (4): KundenZaehlerRepository, KundeRepository, KundennummerService, KundennummerServiceTest
 
 ### Community 243 - "Community 243"
-Cohesion: 0.25
-Nodes (3): failure(), success(), SystemSettingsService
-
-### Community 246 - "Community 246"
-Cohesion: 0.25
-Nodes (3): KasseEinstellungRepository, EhegattengehaltSchedulerService, EhegattengehaltSchedulerServiceTest
+Cohesion: 0.18
+Nodes (6): AddressValue, calledUrls, mockFetch, { onChange }, photonResponse, user
 
 ### Community 249 - "Community 249"
-Cohesion: 0.03
-Nodes (53): DetailLayout(), DetailLayoutProps, EmailHistoryProps, GoogleMapsEmbedProps, LieferantNotizenTab(), LieferantNotizenTabProps, PhoneInput(), PhoneInputProps (+45 more)
+Cohesion: 0.11
+Nodes (12): DANGEROUS_TAGS, DOKUMENT_TYP_LABELS, ExportEntry, FrontendUserSelection, KATEGORIE_LABELS, MONATSNAMEN, prepareHtmlForSending(), sanitizeNode() (+4 more)
 
 ### Community 251 - "Community 251"
 Cohesion: 0.15
 Nodes (13): code:powershell (Test-NetConnection -ComputerName 192.168.x.x -Port 3307), code:powershell (Test-Path "C:\Program Files\MySQL\MySQL Server 8.0\bin\mysql), code:powershell (Get-ScheduledTask -TaskName "Kalkulationsprogramm - Auto Sta), code:powershell (java -version), code:powershell (Test-Path "C:\Kalkulationsprogramm\Kalkulationsprogramm.jar"), code:powershell (Test-NetConnection -ComputerName localhost -Port 8082), code:powershell (C:\Kalkulationsprogramm\scripts\restart-kalkulationsprogramm), Problem: Alte Backups werden nicht gelöscht (+5 more)
 
 ### Community 252 - "Community 252"
-Cohesion: 0.09
-Nodes (7): KundeDuplikatException, FalscheAuftragsnummerException, ForbiddenException, NotFoundException, RuntimeException, FunnelAnfrageAbgelehntException, KasseUnterdeckungException
+Cohesion: 0.07
+Nodes (8): KundeDuplikatException, FalscheAuftragsnummerException, ForbiddenException, MietabrechnungValidationException, NotFoundException, RuntimeException, FunnelAnfrageAbgelehntException, KasseUnterdeckungException
 
 ### Community 253 - "Community 253"
 Cohesion: 0.15
@@ -1559,20 +1572,16 @@ Cohesion: 0.17
 Nodes (12): 3.1 底色不用纯黑纯白, 3.2 Easing 绝不是 linear, 3.3 Slow-Fast-Boom-Stop 叙事, 3.4 展示「过程」而非「魔法结果」, 3.5 鼠标轨迹人工绘制（弧线 + Perlin Noise）, 3.6 Logo「形变收束」(Morph), 3.7 衬线 + 无衬线双字体, 3.8 焦点切换 = 背景减弱 + 前景锐化 + Flash 引导 (+4 more)
 
 ### Community 273 - "Community 273"
-Cohesion: 0.08
-Nodes (3): BelegKategorie, BelegRepository, BelegService
+Cohesion: 0.07
+Nodes (4): BelegKategorie, BelegRepository, BelegService, KasseSaldoServiceTest
 
 ### Community 274 - "Community 274"
-Cohesion: 0.16
-Nodes (15): __emval_addMethodCaller(), __emval_as(), __emval_call_void_method(), __emval_get_method_caller(), __emval_get_property(), __emval_lookupTypes(), __emval_new_array(), __emval_new_cstring() (+7 more)
-
-### Community 276 - "Community 276"
-Cohesion: 0.23
-Nodes (3): AbteilungBerechtigungController, identity(), AbteilungDokumentBerechtigungRepository
+Cohesion: 0.21
+Nodes (12): __emval_as(), __emval_call_void_method(), __emval_get_property(), __emval_new_array(), __emval_new_cstring(), __emval_register(), __emval_set_property(), __emval_take_value() (+4 more)
 
 ### Community 277 - "Community 277"
-Cohesion: 0.04
-Nodes (43): AttachmentProps, EmailAttachmentCard(), EmailAttachmentCardProps, getAttachmentIcon(), isImageAttachment(), Kostenstelle, KostenstelleSelectModal(), KostenstelleSelectModalProps (+35 more)
+Cohesion: 0.05
+Nodes (40): DocumentPreviewModal(), isPdfUrl(), PreviewDoc, KundeSearchItem, KundeSearchModal(), KundeSearchModalProps, isPdfUrl(), AUSGANGS_TYP_BADGE (+32 more)
 
 ### Community 279 - "Community 279"
 Cohesion: 0.18
@@ -1595,40 +1604,52 @@ Cohesion: 0.18
 Nodes (11): code:block4 (我的Deck/), code:html (<!DOCTYPE html>), code:js (window.DECK_MANIFEST = [), code:bash (open slides/05-personas.html), `shared/tokens.css` 该放什么, 单页验证（这是多文件架构的杀手级优势）, 并行开发, 拼接器：`deck_index.html` (+3 more)
 
 ### Community 286 - "Community 286"
-Cohesion: 0.18
-Nodes (13): __embind_register_bool(), __embind_register_emval(), __embind_register_float(), __embind_register_integer(), __embind_register_memory_view(), __embind_register_std_wstring(), __embind_register_void(), __emval_decref() (+5 more)
+Cohesion: 0.31
+Nodes (9): craftInvokerFunction(), createNamedFunction(), __embind_register_class(), __emval_addMethodCaller(), __emval_get_method_caller(), __emval_lookupTypes(), extendError(), makeLegalFunctionName() (+1 more)
+
+### Community 288 - "Community 288"
+Cohesion: 0.10
+Nodes (3): ProjektControllerTest, AktualisiereProjektPreisAusDokumenten, DateiSpeicherServiceTest
 
 ### Community 289 - "Community 289"
-Cohesion: 0.19
-Nodes (4): FrontendUserDetailsService, CsrfCookieFilter, SecurityConfig, UserDetailsService
+Cohesion: 0.25
+Nodes (3): FrontendUserDetailsService, SecurityConfig, UserDetailsService
 
 ### Community 290 - "Community 290"
-Cohesion: 0.09
+Cohesion: 0.08
 Nodes (3): RaumVerbrauchController, RaumVerbrauchService, ZaehlerstandRepository
 
 ### Community 292 - "Community 292"
-Cohesion: 0.08
-Nodes (5): getBeschreibung(), ProjektMapper, ProjektSimple, BestellungService, ZeiterfassungApiService
+Cohesion: 0.07
+Nodes (8): getBeschreibung(), Projekt, ProjektMapper, ProjektSimple, BestellungService, ProjektManagementServiceIT, ZeiterfassungApiService, ZugferdConverterService
 
 ### Community 295 - "Community 295"
 Cohesion: 0.18
 Nodes (10): background_color, description, display, icons, name, orientation, scope, short_name (+2 more)
 
 ### Community 297 - "Community 297"
-Cohesion: 0.13
-Nodes (9): SeenSenderDomainRepository, AusgangsordnerVerarbeitung, DuplikatErkennung, EmailImportServiceTest, FehlerBehandlung, LieferantenNewsletter, NewsletterMarkierung, ParentEmailVerknuepfung (+1 more)
+Cohesion: 0.08
+Nodes (10): SeenSenderDomainRepository, SteuerberaterKontaktRepository, AusgangsordnerVerarbeitung, DuplikatErkennung, EmailImportServiceTest, FehlerBehandlung, LieferantenNewsletter, NewsletterMarkierung (+2 more)
+
+### Community 299 - "Community 299"
+Cohesion: 0.11
+Nodes (4): toAnredeText(), leer(), AutoAuftragsbestaetigungVersandServicePreview, AutoMahnVersandServicePreview
 
 ### Community 301 - "Community 301"
 Cohesion: 0.20
 Nodes (9): code:batch (iexpress /N setup-config.sed), 📦 Das fertige Setup verteilen, Einmalige Vorbereitung:, ℹ️ Empfehlung, ⭐ Option 1: IExpress (bereits in Windows), 🏆 Option 2: Inno Setup (professioneller), 🔄 Setup aktualisieren, Setup erstellen: (+1 more)
 
 ### Community 302 - "Community 302"
-Cohesion: 0.07
-Nodes (8): BwaUploadRepository, BwaService, BwaServiceTest, Delete, FindAvailableYears, FindById, FindByJahr, FindStoredFilename
+Cohesion: 0.13
+Nodes (6): BwaServiceTest, Delete, FindAvailableYears, FindById, FindByJahr, FindStoredFilename
 
 ### Community 305 - "Community 305"
-Cohesion: 0.12
-Nodes (4): BuildKategoriePfadTests, GeneratePdfValidierungTests, ProjektAuswertungPdfServiceTest, ResolveGroupKeyTests
+Cohesion: 0.07
+Nodes (7): ProjektAuswertungPdfService, BuildComparatorTests, BuildKategoriePfadTests, GeneratePdfValidierungTests, GroupByLabelTests, ProjektAuswertungPdfServiceTest, ResolveGroupKeyTests
+
+### Community 308 - "Community 308"
+Cohesion: 0.08
+Nodes (5): AusgangsrechnungDto, EingangsrechnungDto, MergePdfRequest, RechnungsuebersichtController, ProjektDokumentRepository
 
 ### Community 315 - "Community 315"
 Cohesion: 0.11
@@ -1654,17 +1675,17 @@ Nodes (9): 17. Takram - 日式思辨设计, 18. Kenya Hara - 空的设计, 19. I
 Cohesion: 0.22
 Nodes (9): 09. Experimental Jetset - 概念极简, 10. Müller-Brockmann传承 - 瑞士网格纯粹主义, 11. Build - 当代极简品牌, 12. Sagmeister & Walsh - 快乐极简, code:block10 (Josef Müller-Brockmann Swiss modernism:), code:block11 (Build studio luxury minimalism:), code:block12 (Sagmeister & Walsh joyful philosophy:), code:block9 (Experimental Jetset conceptual minimalism:) (+1 more)
 
-### Community 322 - "Community 322"
-Cohesion: 0.08
-Nodes (4): EmailController, Email, EmailSignatureImage, LieferantDokumentRepositoryTest
+### Community 324 - "Community 324"
+Cohesion: 0.13
+Nodes (3): AbteilungBerechtigungController, BelegController, identity()
 
 ### Community 325 - "Community 325"
 Cohesion: 0.05
 Nodes (8): KiHilfeController, text(), AnfrageRepository, AnfrageRepositoryTest, KundeNotizRepository, KundenDetailService, KundenDetailServiceTest, LoadDetails
 
 ### Community 326 - "Community 326"
-Cohesion: 0.08
-Nodes (8): ZeitverwaltungControllerTest, Berechnung, CacheVerhalten, Fehlerfaelle, MonatsSaldoEntity, MonatsSaldoServiceTest, ZeitkontoService, ZeitkontoServiceTest
+Cohesion: 0.12
+Nodes (6): ZeitverwaltungControllerTest, Berechnung, CacheVerhalten, Fehlerfaelle, MonatsSaldoServiceTest, ZeitkontoServiceTest
 
 ### Community 327 - "Community 327"
 Cohesion: 0.25
@@ -1711,20 +1732,20 @@ Cohesion: 0.36
 Nodes (4): Create-AutoStartTask(), Create-BackupTask(), Create-WeeklyRestartTask(), Remove-ExistingTask()
 
 ### Community 343 - "Community 343"
-Cohesion: 0.25
+Cohesion: 0.20
 Nodes (3): FrontendUserController, SaveProfileRequest, SetDefaultSignatureRequest
 
-### Community 346 - "Community 346"
-Cohesion: 0.04
-Nodes (39): CreateReklamationModal(), CreateReklamationModalProps, Lieferschein, ImageViewerModalProps, LieferantReklamationenTabProps, FrontendUserSelection, MitarbeiterStunden, SteuerberaterAnsprechpartner (+31 more)
-
 ### Community 347 - "Community 347"
-Cohesion: 0.22
-Nodes (4): CloudflareAccessJwtFilter, ZeiterfassungSecurityFilter, OncePerRequestFilter, before
+Cohesion: 0.17
+Nodes (5): CloudflareAccessJwtFilter, CsrfCookieFilter, ZeiterfassungSecurityFilter, OncePerRequestFilter, before
 
 ### Community 349 - "Community 349"
-Cohesion: 0.12
-Nodes (3): GetThread, EmailThreadService, EmailThreadServiceTest
+Cohesion: 0.13
+Nodes (3): GetThread, EmailDraftRepository, EmailThreadServiceTest
+
+### Community 350 - "Community 350"
+Cohesion: 0.25
+Nodes (7): mockFetch, mockHauptkategorien, mockSearchResults, onClose, onConfirm, searchInput, user
 
 ### Community 351 - "Community 351"
 Cohesion: 0.40
@@ -1743,8 +1764,8 @@ Cohesion: 0.25
 Nodes (7): AnalyticsSnapshotResponseDto, BrowserCount, CityCount, DeviceCount, FunnelStep, TopPage, Totals
 
 ### Community 356 - "Community 356"
-Cohesion: 0.17
-Nodes (3): GetTemplate, NamedTemplates, SaveTemplate
+Cohesion: 0.13
+Nodes (5): FormularTemplateControllerTest, GetTemplate, NamedTemplates, PlatzhalterUndNummer, SaveTemplate
 
 ### Community 358 - "Community 358"
 Cohesion: 0.29
@@ -1755,12 +1776,8 @@ Cohesion: 0.29
 Nodes (6): Hardware-Anforderungen, Kalkulationsprogramm - Deployment Guide, Software-Anforderungen, Support, Voraussetzungen, Übersicht
 
 ### Community 362 - "Community 362"
-Cohesion: 0.06
-Nodes (30): DocumentLockedModal(), DocumentLockedModalProps, formatBearbeitetSeit(), Eingangsrechnung, EingangsrechnungenTab(), EingangsrechnungenTabProps, formatEuro(), DEFAULT_CONFIG (+22 more)
-
-### Community 364 - "Community 364"
-Cohesion: 0.22
-Nodes (3): FormularTemplateControllerTest, PlatzhalterUndNummer, UploadLogo
+Cohesion: 0.03
+Nodes (62): DocumentLockedModal(), DocumentLockedModalProps, formatBearbeitetSeit(), DocumentCard(), DocumentCardProps, DocumentGroup(), DocumentGroupProps, DocumentManager() (+54 more)
 
 ### Community 365 - "Community 365"
 Cohesion: 0.29
@@ -1783,8 +1800,8 @@ Cohesion: 0.27
 Nodes (8): Camera, CameraHandle, CameraProps, acquireCameraStream(), getActiveCameraStream(), releaseCameraStream(), streamIsLive(), FakeTrack
 
 ### Community 374 - "Community 374"
-Cohesion: 0.25
-Nodes (7): BelegZuordnungDto, BelegZuordnungRequest, DokumentRef, GeschaeftsdatenDto, ProjektAnteil, ZuordnungDto, ZuordnungRequest
+Cohesion: 0.33
+Nodes (7): createNamedFunction(), __emval_addMethodCaller(), __emval_get_method_caller(), __emval_lookupTypes(), extendError(), makeLegalFunctionName(), new_()
 
 ### Community 376 - "Community 376"
 Cohesion: 0.33
@@ -1793,6 +1810,10 @@ Nodes (7): AufteilungsSektion(), AuswertungView(), BelegRow(), formatDate(), for
 ### Community 377 - "Community 377"
 Cohesion: 0.33
 Nodes (7): __dirname, getDuration(), main(), parseArgs(), SKILL_ROOT, tts(), usage()
+
+### Community 378 - "Community 378"
+Cohesion: 0.29
+Nodes (7): downcastPointer(), getBasestPointer(), getInheritedInstance(), makeClassHandle(), RegisteredPointer_fromWireType(), replacePublicSymbol(), throwInternalError()
 
 ### Community 379 - "Community 379"
 Cohesion: 0.47
@@ -1834,17 +1855,9 @@ Nodes (6): §0.1 身份锚点, §0.2 核心信念（3 条）, §0.3 品味标准
 Cohesion: 0.29
 Nodes (5): defaultProps, inputs, mockFetch, postCall, spinbuttons
 
-### Community 396 - "Community 396"
-Cohesion: 0.29
-Nodes (6): AnteilDto, DokumentKetteRefDto, EingangsrechnungDto, ProjektNotizBildDto, ProjektNotizCreateDto, ProjektNotizDto
-
 ### Community 398 - "Community 398"
 Cohesion: 0.20
-Nodes (4): B(), he, O(), ye()
-
-### Community 399 - "Community 399"
-Cohesion: 0.33
-Nodes (4): AbwesenheitenPageProps, Antrag, statusConfig, typConfig
+Nodes (3): B(), he, O()
 
 ### Community 400 - "Community 400"
 Cohesion: 0.13
@@ -1859,12 +1872,8 @@ Cohesion: 0.40
 Nodes (4): ending, intro, token-1, token-2
 
 ### Community 404 - "Community 404"
-Cohesion: 0.29
-Nodes (6): { container }, handleClose, images, img, out, user
-
-### Community 405 - "Community 405"
-Cohesion: 0.29
-Nodes (7): alignUp(), dynamicAlloc(), _emscripten_get_heap_size(), emscripten_realloc_buffer(), _emscripten_resize_heap(), getMemory(), updateGlobalBufferAndViews()
+Cohesion: 0.33
+Nodes (4): AbwesenheitenPageProps, Antrag, statusConfig, typConfig
 
 ### Community 406 - "Community 406"
 Cohesion: 0.40
@@ -1883,8 +1892,8 @@ Cohesion: 0.40
 Nodes (4): Sicherheitslücken melden, Sicherheitsmaßnahmen im Projekt, Sicherheitsrichtlinie, Unterstützte Versionen
 
 ### Community 412 - "Community 412"
-Cohesion: 0.33
-Nodes (7): createNamedFunction(), __emval_addMethodCaller(), __emval_get_method_caller(), __emval_lookupTypes(), extendError(), makeLegalFunctionName(), new_()
+Cohesion: 0.38
+Nodes (5): CITY_TO_AREA_CODE, lookupAreaCode(), normalizeOrt(), PLZ_PREFIX2_TO_AREA_CODE, PLZ_PREFIX3_TO_AREA_CODE
 
 ### Community 413 - "Community 413"
 Cohesion: 0.40
@@ -1910,10 +1919,6 @@ Nodes (3): EmailTextTemplateController, EmailTextTemplateDto, EmailTextTemplateK
 Cohesion: 0.18
 Nodes (15): addDays(), ANREDE_LABELS, EMPTY_TEMPLATE, escapeHtml(), formatAdresse(), formatAnrede(), formatDate(), highlightPlaceholder() (+7 more)
 
-### Community 419 - "Community 419"
-Cohesion: 0.22
-Nodes (7): request(), fetchAnfrageLastAccessed(), trackAnfrageAccess(), fetchProjektLastAccessed(), trackProjektAccess(), isServerReachable(), g
-
 ### Community 420 - "Community 420"
 Cohesion: 0.40
 Nodes (5): 2. Easing 哲学 · 拒绝 linear，拥抱物理, code:js (// 1. Expo Out · 迅速启动缓慢刹车（最常用，默认主 easing）), 三个核心 Easing（animations.jsx 已内置）, 反直觉洞察, 用法映射
@@ -1931,20 +1936,24 @@ Cohesion: 0.40
 Nodes (5): code:block3 (│ 问：deck 预计有多少页？), 两种架构对比, 为什么这条规则这么硬？（真实事故记录）, 🛑 先定架构：单文件 还是 多文件？, 选哪个？（决策树）
 
 ### Community 424 - "Community 424"
-Cohesion: 0.29
-Nodes (7): downcastPointer(), getBasestPointer(), getInheritedInstance(), makeClassHandle(), RegisteredPointer_fromWireType(), replacePublicSymbol(), throwInternalError()
-
-### Community 430 - "Community 430"
 Cohesion: 0.33
 Nodes (5): Feiertag, Mitarbeiter, SaldenPage(), SaldenPageProps, SaldoData
+
+### Community 429 - "Community 429"
+Cohesion: 0.11
+Nodes (5): KostenpositionMapping, MieteMapperTest, MietobjektMapping, MietparteiMapping, ZaehlerstandMapping
+
+### Community 431 - "Community 431"
+Cohesion: 0.08
+Nodes (3): ArtikelController, ArtikelMatchingService, ArtikelMatchingServiceTest
 
 ### Community 432 - "Community 432"
 Cohesion: 0.40
 Nodes (4): AbteilungBerechtigungDto, Response, TypBerechtigung, UpdateRequest
 
-### Community 435 - "Community 435"
-Cohesion: 0.12
-Nodes (4): LeistungMapper, ToDto, ProduktkategorieMapper, ProduktkategorieMapperTest
+### Community 446 - "Community 446"
+Cohesion: 0.29
+Nodes (6): { container }, handleClose, images, img, out, user
 
 ### Community 447 - "Community 447"
 Cohesion: 0.50
@@ -1966,21 +1975,13 @@ Nodes (3): main(), parse_viewport(), verify_html()
 Cohesion: 0.29
 Nodes (7): alignUp(), dynamicAlloc(), _emscripten_get_heap_size(), emscripten_realloc_buffer(), _emscripten_resize_heap(), getMemory(), updateGlobalBufferAndViews()
 
+### Community 492 - "Community 492"
+Cohesion: 0.29
+Nodes (7): downcastPointer(), getBasestPointer(), getInheritedInstance(), makeClassHandle(), RegisteredPointer_fromWireType(), replacePublicSymbol(), throwInternalError()
+
 ### Community 496 - "Community 496"
 Cohesion: 0.67
 Nodes (3): 工作流程, 标准流程（用TaskCreate追踪）, 问问题的要点
-
-### Community 789 - "Community 789"
-Cohesion: 0.47
-Nodes (3): PdfPCellEvent, CheckboxCellEvent, LeftCheckboxCellEvent
-
-### Community 793 - "Community 793"
-Cohesion: 0.50
-Nodes (3): LieferantSearchModal(), LieferantSearchModalProps, LieferantSuchErgebnis
-
-### Community 795 - "Community 795"
-Cohesion: 0.27
-Nodes (3): EmailAutoAssignmentService, EntityOption, PossibleAssignments
 
 ### Community 798 - "Community 798"
 Cohesion: 0.50
@@ -1993,17 +1994,17 @@ Nodes (3): AusgangsGeschaeftsDokumentAudit, AusgangsGeschaeftsDokumentAuditCanon
 ## Knowledge Gaps
 - **2141 isolated node(s):** `version`, `source`, `sourceType`, `skillPath`, `computedHash` (+2136 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **433 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **429 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `Select()` connect `Community 229` to `Community 0`, `Community 1`, `Community 5`, `Community 6`, `Community 136`, `Community 12`, `Community 17`, `Community 34`, `Community 418`, `Community 39`, `Community 40`, `Community 431`, `Community 826`, `Community 196`, `Community 346`, `Community 218`, `Community 352`, `Community 362`, `Community 107`, `Community 112`, `Community 249`?**
-  _High betweenness centrality (0.126) - this node is a cross-community bridge._
-- **Why does `body` connect `Community 45` to `Community 514`, `Community 3`, `Community 132`, `Community 134`, `Community 7`, `Community 136`, `Community 394`, `Community 395`, `Community 268`, `Community 13`, `Community 275`, `Community 788`, `Community 149`, `Community 278`, `Community 23`, `Community 22`, `Community 281`, `Community 794`, `Community 28`, `Community 287`, `Community 288`, `Community 32`, `Community 162`, `Community 33`, `Community 36`, `Community 165`, `Community 290`, `Community 41`, `Community 298`, `Community 43`, `Community 426`, `Community 174`, `Community 175`, `Community 304`, `Community 49`, `Community 818`, `Community 185`, `Community 57`, `Community 826`, `Community 188`, `Community 191`, `Community 64`, `Community 192`, `Community 322`, `Community 323`, `Community 67`, `Community 325`, `Community 199`, `Community 201`, `Community 75`, `Community 204`, `Community 205`, `Community 206`, `Community 79`, `Community 81`, `Community 84`, `Community 343`, `Community 215`, `Community 219`, `Community 350`, `Community 97`, `Community 100`, `Community 231`, `Community 234`, `Community 237`, `Community 110`, `Community 378`, `Community 245`, `Community 248`, `Community 250`, `Community 252`?**
-  _High betweenness centrality (0.106) - this node is a cross-community bridge._
-- **Why does `empty()` connect `Community 237` to `Community 2`, `Community 130`, `Community 135`, `Community 7`, `Community 11`, `Community 268`, `Community 141`, `Community 142`, `Community 146`, `Community 275`, `Community 20`, `Community 19`, `Community 22`, `Community 21`, `Community 154`, `Community 27`, `Community 28`, `Community 29`, `Community 155`, `Community 32`, `Community 288`, `Community 36`, `Community 165`, `Community 38`, `Community 39`, `Community 293`, `Community 169`, `Community 166`, `Community 171`, `Community 44`, `Community 173`, `Community 302`, `Community 48`, `Community 178`, `Community 55`, `Community 58`, `Community 187`, `Community 188`, `Community 60`, `Community 189`, `Community 322`, `Community 67`, `Community 325`, `Community 326`, `Community 72`, `Community 329`, `Community 200`, `Community 74`, `Community 77`, `Community 82`, `Community 84`, `Community 212`, `Community 91`, `Community 349`, `Community 222`, `Community 93`, `Community 97`, `Community 230`, `Community 231`, `Community 105`, `Community 234`, `Community 106`, `Community 108`, `Community 241`, `Community 115`, `Community 116`, `Community 245`, `Community 246`, `Community 247`, `Community 122`?**
-  _High betweenness centrality (0.042) - this node is a cross-community bridge._
+- **Why does `Select()` connect `Community 5` to `Community 0`, `Community 1`, `Community 6`, `Community 136`, `Community 12`, `Community 277`, `Community 418`, `Community 40`, `Community 169`, `Community 299`, `Community 431`, `Community 826`, `Community 196`, `Community 218`, `Community 352`, `Community 229`, `Community 103`, `Community 362`, `Community 107`, `Community 112`, `Community 249`?**
+  _High betweenness centrality (0.123) - this node is a cross-community bridge._
+- **Why does `body` connect `Community 45` to `Community 514`, `Community 3`, `Community 4`, `Community 132`, `Community 131`, `Community 7`, `Community 136`, `Community 394`, `Community 395`, `Community 268`, `Community 275`, `Community 788`, `Community 149`, `Community 278`, `Community 22`, `Community 23`, `Community 281`, `Community 27`, `Community 28`, `Community 287`, `Community 33`, `Community 162`, `Community 290`, `Community 35`, `Community 165`, `Community 41`, `Community 298`, `Community 43`, `Community 297`, `Community 426`, `Community 175`, `Community 818`, `Community 308`, `Community 185`, `Community 57`, `Community 826`, `Community 188`, `Community 191`, `Community 64`, `Community 322`, `Community 323`, `Community 324`, `Community 325`, `Community 199`, `Community 201`, `Community 75`, `Community 204`, `Community 334`, `Community 79`, `Community 206`, `Community 81`, `Community 82`, `Community 84`, `Community 343`, `Community 215`, `Community 93`, `Community 95`, `Community 97`, `Community 100`, `Community 231`, `Community 232`, `Community 237`, `Community 110`, `Community 252`, `Community 245`, `Community 246`, `Community 250`, `Community 124`?**
+  _High betweenness centrality (0.101) - this node is a cross-community bridge._
+- **Why does `cn()` connect `Community 5` to `Community 0`, `Community 1`, `Community 129`, `Community 418`, `Community 160`, `Community 229`, `Community 6`, `Community 103`, `Community 40`, `Community 362`, `Community 107`, `Community 12`, `Community 46`, `Community 179`, `Community 218`?**
+  _High betweenness centrality (0.039) - this node is a cross-community bridge._
 - **Are the 184 inferred relationships involving `body` (e.g. with `.bucheAbwesenheit()` and `.empfangeSnapshot()`) actually correct?**
   _`body` has 184 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 168 inferred relationships involving `Filter` (e.g. with `.getAllBerechtigungen()` and `.getBerechtigungen()`) actually correct?**

--- a/src/main/java/org/example/kalkulationsprogramm/controller/LieferantenController.java
+++ b/src/main/java/org/example/kalkulationsprogramm/controller/LieferantenController.java
@@ -92,16 +92,9 @@ public class LieferantenController {
     private final org.example.kalkulationsprogramm.repository.EmailRepository emailRepository;
     private final org.example.kalkulationsprogramm.service.FrontendUserProfileService frontendUserProfileService;
     private final org.example.kalkulationsprogramm.service.EmailSignatureService emailSignatureService;
+    private final org.example.kalkulationsprogramm.service.SystemSettingsService systemSettingsService;
     private final org.springframework.context.ApplicationEventPublisher eventPublisher;
 
-    @org.springframework.beans.factory.annotation.Value("${smtp.host}")
-    private String smtpHost;
-    @org.springframework.beans.factory.annotation.Value("${smtp.port}")
-    private int smtpPort;
-    @org.springframework.beans.factory.annotation.Value("${smtp.username}")
-    private String smtpUsername;
-    @org.springframework.beans.factory.annotation.Value("${smtp.password}")
-    private String smtpPassword;
     @org.springframework.beans.factory.annotation.Value("${file.mail-attachment-dir}")
     private String mailAttachmentDir;
     @org.springframework.beans.factory.annotation.Value("${file.upload-dir}")
@@ -303,8 +296,11 @@ public class LieferantenController {
             return ResponseEntity.notFound().build();
         }
 
-        org.example.email.EmailService emailService = new org.example.email.EmailService(smtpHost, smtpPort,
-                smtpUsername, smtpPassword);
+        org.example.email.EmailService emailService = new org.example.email.EmailService(
+                systemSettingsService.getSmtpHost(),
+                systemSettingsService.getSmtpPort(),
+                systemSettingsService.getSmtpUsername(),
+                systemSettingsService.getSmtpPassword());
 
         String htmlBody = dto.getBody() != null ? dto.getBody() : "";
         String userName = resolveUserName(dto.getBenutzer(), dto.getFrontendUserId());

--- a/src/test/java/org/example/kalkulationsprogramm/config/ValuePlaceholderKonfigurationTest.java
+++ b/src/test/java/org/example/kalkulationsprogramm/config/ValuePlaceholderKonfigurationTest.java
@@ -1,0 +1,107 @@
+package org.example.kalkulationsprogramm.config;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Parameter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.stereotype.Component;
+
+/**
+ * Regressionstest für Issue #68: Die Release-.exe (h2-Profil) crashte beim
+ * Start mit "Could not resolve placeholder 'smtp.host'", weil der
+ * LieferantenController {@code @Value("${smtp.host}")} ohne Default nutzte
+ * und smtp.* nur in der gitignorten application-local.properties definiert
+ * war. Beim Endnutzer (ohne local-Profil) konnte Spring den Platzhalter
+ * nicht auflösen und beendete den Boot.
+ *
+ * Dieser Test stellt sicher, dass jeder @Value-Platzhalter OHNE
+ * Default-Wert in der Basis-application.properties definiert ist (die in
+ * jedem Profil geladen wird) oder eine JVM-System-Property ist
+ * (z.B. user.dir, user.home).
+ */
+class ValuePlaceholderKonfigurationTest {
+
+    /** Findet ${...}-Vorkommen; Gruppe 1 ist der Inhalt zwischen den Klammern. */
+    private static final Pattern PLACEHOLDER = Pattern.compile("\\$\\{([^}]*)\\}");
+
+    @Test
+    void allePlaceholderOhneDefaultSindInBasisPropertiesDefiniert() throws Exception {
+        Properties basis = ladeBasisProperties();
+        List<String> verstoesse = new ArrayList<>();
+
+        ClassPathScanningCandidateComponentProvider scanner = new ClassPathScanningCandidateComponentProvider(false);
+        scanner.addIncludeFilter(new AnnotationTypeFilter(Component.class));
+
+        for (BeanDefinition bd : scanner.findCandidateComponents("org.example")) {
+            Class<?> clazz;
+            try {
+                clazz = Class.forName(bd.getBeanClassName());
+            } catch (ClassNotFoundException | NoClassDefFoundError e) {
+                continue;
+            }
+            for (Field field : clazz.getDeclaredFields()) {
+                pruefeAnnotation(field.getAnnotation(Value.class),
+                        clazz.getSimpleName() + "." + field.getName(), basis, verstoesse);
+            }
+            for (Constructor<?> constructor : clazz.getDeclaredConstructors()) {
+                for (Parameter parameter : constructor.getParameters()) {
+                    pruefeAnnotation(parameter.getAnnotation(Value.class),
+                            clazz.getSimpleName() + "(" + parameter.getName() + ")", basis, verstoesse);
+                }
+            }
+        }
+
+        assertTrue(verstoesse.isEmpty(),
+                "Diese @Value-Platzhalter haben keinen Default und sind nicht in der Basis-"
+                        + "application.properties definiert – sie crashen den Boot der Release-.exe "
+                        + "(vgl. Issue #68). Entweder Default angeben (${key:default}) oder den Wert "
+                        + "über SystemSettingsService beziehen:\n"
+                        + String.join("\n", verstoesse));
+    }
+
+    private void pruefeAnnotation(Value annotation, String ort, Properties basis, List<String> verstoesse) {
+        if (annotation == null) {
+            return;
+        }
+        Matcher matcher = PLACEHOLDER.matcher(annotation.value());
+        while (matcher.find()) {
+            String inhalt = matcher.group(1);
+            if (inhalt.contains(":")) {
+                continue; // hat einen Default -> Boot kann nicht daran scheitern
+            }
+            if (basis.containsKey(inhalt) || System.getProperties().containsKey(inhalt)) {
+                continue;
+            }
+            verstoesse.add("  - " + ort + " -> ${" + inhalt + "}");
+        }
+    }
+
+    /**
+     * Lädt bewusst src/main/resources/application.properties direkt vom
+     * Dateisystem: Im Test-Classpath würde src/test/resources/application.properties
+     * gewinnen, die (anders als das Release) smtp.* definiert.
+     */
+    private Properties ladeBasisProperties() throws Exception {
+        Properties properties = new Properties();
+        Path pfad = Path.of("src", "main", "resources", "application.properties");
+        try (InputStream in = Files.newInputStream(pfad)) {
+            properties.load(in);
+        }
+        return properties;
+    }
+}

--- a/src/test/java/org/example/kalkulationsprogramm/controller/LieferantenControllerTest.java
+++ b/src/test/java/org/example/kalkulationsprogramm/controller/LieferantenControllerTest.java
@@ -93,6 +93,8 @@ class LieferantenControllerTest {
   private org.example.kalkulationsprogramm.repository.KostenstelleRepository kostenstelleRepository;
   @MockBean
   private org.example.kalkulationsprogramm.service.LieferantStandardKostenstelleAutoAssigner standardKostenstelleAutoAssigner;
+  @MockBean
+  private org.example.kalkulationsprogramm.service.SystemSettingsService systemSettingsService;
 
   @Autowired
   private LieferantenController controller;


### PR DESCRIPTION
## Problem (Issue #68)
Die Release-.exe (h2-Profil) crashte beim Start mit `BeanCreationException: lieferantenController` / `Could not resolve placeholder 'smtp.host'`. Ursache: `LieferantenController` injizierte `smtp.host/port/username/password` per `@Value` **ohne Default** – diese Properties existieren nur in der gitignorten `application-local.properties`, die im Release fehlt.

## Fix
- `LieferantenController` bezieht die SMTP-Zugangsdaten jetzt über den `SystemSettingsService` (gleiches Muster wie `EmailController`). Damit greifen auch die in der UI eingetragenen SMTP-Einstellungen beim Lieferanten-Mailversand.
- Regressionstest `ValuePlaceholderKonfigurationTest`: scannt alle Beans und schlägt fehl, wenn ein `@Value`-Platzhalter ohne Default nicht in der Basis-`application.properties` definiert ist (rot am alten Stand nachgewiesen).
- `LieferantenControllerTest`: fehlendes `@MockBean SystemSettingsService` ergänzt.

## Verifikation
- Voller Backend-Testlauf: 1528 Tests, 0 Failures, 0 Errors ✅
- End-to-End: Jar im Release-Szenario gestartet (`--spring.profiles.active=h2`, frisches Home-Verzeichnis) → Boot bis "Started" (27 s), Startseite HTTP 200, `/api/lieferanten` HTTP 200 ✅
- Review: erp-code-reviewer 🟢 + Codex-Zweitmeinung ohne kritische Findings ✅

Fixes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)