### PR TITLE
fix(email): preserve attachment filenames

### DIFF
--- a/src/main/java/org/example/email/EmailService.java
+++ b/src/main/java/org/example/email/EmailService.java
@@ -34,6 +34,14 @@ import jakarta.mail.util.ByteArrayDataSource;
 public class EmailService {
 
     /**
+     * A mail attachment with its display name kept separate from its temporary
+     * file on disk.  Temporary file names are implementation details and must
+     * never be exposed in MIME headers.
+     */
+    public record Attachment(File file, String filename, String mimeType) {
+    }
+
+    /**
      * Marker-Header, den jede vom ERP versendete Mail traegt.
      *
      * <p><strong>Er filtert nichts.</strong> Dass die eigene Sent-Kopie nicht
@@ -440,7 +448,7 @@ public class EmailService {
             String subject,
             String htmlBody,
             java.util.Map<String, java.io.File> inlineCidToFile,
-            java.util.List<String> attachmentFilePaths) throws MessagingException, IOException {
+            java.util.List<Attachment> attachments) throws MessagingException, IOException {
         Properties props = new Properties();
         props.put("mail.smtp.host", host);
         props.put("mail.smtp.port", String.valueOf(port));
@@ -501,16 +509,20 @@ public class EmailService {
         }
 
         // Add multiple attachments
-        if (attachmentFilePaths != null) {
-            for (String attachmentFilePath : attachmentFilePaths) {
-                if (attachmentFilePath != null && !attachmentFilePath.isBlank()) {
-                    File attachFile = new File(attachmentFilePath);
-                    if (attachFile.exists()) {
-                        MimeBodyPart attachmentPart = new MimeBodyPart();
-                        attachmentPart.attachFile(attachFile);
-                        attachmentPart.setFileName(attachFile.getName());
-                        mixed.addBodyPart(attachmentPart);
+        if (attachments != null) {
+            for (Attachment attachment : attachments) {
+                if (attachment != null && attachment.file() != null && attachment.file().exists()) {
+                    File attachFile = attachment.file();
+                    MimeBodyPart attachmentPart = new MimeBodyPart();
+                    attachmentPart.attachFile(attachFile);
+                    attachmentPart.setDisposition(MimeBodyPart.ATTACHMENT);
+                    attachmentPart.setFileName(attachment.filename() != null && !attachment.filename().isBlank()
+                            ? attachment.filename()
+                            : attachFile.getName());
+                    if (attachment.mimeType() != null && !attachment.mimeType().isBlank()) {
+                        attachmentPart.setHeader("Content-Type", attachment.mimeType());
                     }
+                    mixed.addBodyPart(attachmentPart);
                 }
             }
         }

--- a/src/main/java/org/example/kalkulationsprogramm/controller/LieferantenController.java
+++ b/src/main/java/org/example/kalkulationsprogramm/controller/LieferantenController.java
@@ -322,6 +322,7 @@ public class LieferantenController {
 
         // Handle Attachments (Send & Save)
         List<java.io.File> tempFiles = new ArrayList<>();
+        List<org.example.email.EmailService.Attachment> attachmentsForEmail = new ArrayList<>();
         try {
             // 1. Send Email
             // Note: Our EmailService might need adaptation for attachments.
@@ -370,14 +371,14 @@ public class LieferantenController {
 
                     // Add to send list
                     tempFiles.add(dst.toFile());
+                    attachmentsForEmail.add(new org.example.email.EmailService.Attachment(
+                            dst.toFile(), original, mpf.getContentType()));
                 }
                 emailContext = emailRepository.save(emailContext);
             }
 
             // Actually Send
             String recipients = String.join(",", dto.getRecipients());
-            List<String> attachmentPaths = tempFiles.stream().map(java.io.File::getAbsolutePath).toList();
-
             String msgId = emailService.sendEmailWithMultipleAttachments(
                     recipients,
                     null,
@@ -385,7 +386,7 @@ public class LieferantenController {
                     dto.getSubject(),
                     htmlBody,
                     inline,
-                    attachmentPaths);
+                    attachmentsForEmail);
 
             emailContext.setMessageId(msgId);
             emailRepository.save(emailContext);

--- a/src/main/java/org/example/kalkulationsprogramm/controller/UnifiedEmailController.java
+++ b/src/main/java/org/example/kalkulationsprogramm/controller/UnifiedEmailController.java
@@ -1378,7 +1378,7 @@ public class UnifiedEmailController {
                     .mitSentKopie(sentMailArchiver);
 
             // Attachments vorbereiten
-            List<String> attachmentPaths = new ArrayList<>();
+            List<org.example.email.EmailService.Attachment> attachmentsForEmail = new ArrayList<>();
             List<java.io.File> tempFiles = new ArrayList<>();
 
             // 1. Dokument anhängen (wenn dokumentId angegeben)
@@ -1437,7 +1437,8 @@ public class UnifiedEmailController {
                                 java.nio.file.Files.copy(resource.getFile().toPath(), renamedFile.toPath(),
                                         java.nio.file.StandardCopyOption.REPLACE_EXISTING);
                                 tempFile.delete(); // Original temp file löschen
-                                attachmentPaths.add(renamedFile.getAbsolutePath());
+                                attachmentsForEmail.add(new org.example.email.EmailService.Attachment(
+                                        renamedFile, attachedOriginalFilename, null));
                                 tempFiles.add(renamedFile); // Für spätere Aufräumung
                                 log.info("Dokument '{}' als Anhang hinzugefügt", attachedOriginalFilename);
                             }
@@ -1459,7 +1460,8 @@ public class UnifiedEmailController {
                                 : "attachment";
                         java.io.File tempFile = java.io.File.createTempFile("email_", "_" + safeFilename);
                         file.transferTo(tempFile);
-                        attachmentPaths.add(tempFile.getAbsolutePath());
+                        attachmentsForEmail.add(new org.example.email.EmailService.Attachment(
+                                tempFile, safeFilename, file.getContentType()));
                         tempFiles.add(tempFile);
                     }
                 }
@@ -1501,7 +1503,7 @@ public class UnifiedEmailController {
                     dto.getSubject(),
                     htmlBody,
                     Map.of(),
-                    attachmentPaths);
+                    attachmentsForEmail);
 
             // Email-Entität speichern
             Email email = new Email();
@@ -1634,7 +1636,7 @@ public class UnifiedEmailController {
                     .mitSentKopie(sentMailArchiver);
 
             // Attachments vorbereiten
-            List<String> attachmentPaths = new ArrayList<>();
+            List<org.example.email.EmailService.Attachment> attachmentsForEmail = new ArrayList<>();
             List<java.io.File> tempFiles = new ArrayList<>();
 
             if (attachments != null) {
@@ -1645,7 +1647,8 @@ public class UnifiedEmailController {
                                 : "attachment";
                         java.io.File tempFile = java.io.File.createTempFile("email_", "_" + safeFilename);
                         file.transferTo(tempFile);
-                        attachmentPaths.add(tempFile.getAbsolutePath());
+                        attachmentsForEmail.add(new org.example.email.EmailService.Attachment(
+                                tempFile, safeFilename, file.getContentType()));
                         tempFiles.add(tempFile);
                     }
                 }
@@ -1675,7 +1678,7 @@ public class UnifiedEmailController {
                     dto.getSubject(),
                     htmlBody,
                     Map.of(), // keine Inline-CID-Bilder
-                    attachmentPaths);
+                    attachmentsForEmail);
 
             // Email-Entität speichern
             Email email = new Email();


### PR DESCRIPTION
## Änderung

E-Mail-Anhänge verwenden beim Versand wieder den vom Nutzer benannten Originaldateinamen statt eines temporären oder UUID-basierten Speichernamens.

## Ursache

Der SMTP-Versand leitete zuvor den Namen der temporär gespeicherten Datei in den MIME-Anhang weiter. Dadurch konnte iOS den PDF-Anhang als `mime-attachment` anzeigen.

## Auswirkung

PDFs und andere Anhänge werden mit explizitem MIME-Typ und `Content-Disposition: attachment` sowie dem Originaldateinamen ausgeliefert.

## Prüfung

`mvnw.cmd -q -DskipTests compile`
